### PR TITLE
HOCS-5386: Flatten DECS migration schema.

### DIFF
--- a/src/main/resources/hocs-migration-schema.json
+++ b/src/main/resources/hocs-migration-schema.json
@@ -50,77 +50,57 @@
           }
         ]
       }
-    },
-    "caseDetails": {
-      "description": "All the data for a case",
-      "type": "object",
-      "required": [
-        "caseType",
-        "sourceCaseId",
-        "correspondentName",
-        "correspondenceEmail",
-        "caseStatus",
-        "caseStatusDate",
-        "creationDate",
-        "caseData",
-        "caseAttachments"
-      ],
-      "additionalProperties": false,
-      "properties": {
-        "caseType": {
-          "type":"string"
-        },
-        "sourceCaseId": {
-          "type":"string"
-        },
-        "correspondentName": {
-          "type":"string"
-        },
-        "correspondenceEmail": {
-          "type":"string"
-        },
-        "caseStatus": {
-          "type":"string"
-        },
-        "caseStatusDate": {
-          "type":"string",
-          "format": "date"
-        },
-        "creationDate": {
-          "type": "string",
-          "format": "date"
-        },
-        "caseData": {
-          "anyOf" : [
-            {
-            "$ref": "#/definitions/caseData"
-            }
-          ]
-        },
-        "caseAttachments": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/caseAttachments"
-            }
-          ]
-        }
-      }
     }
   },
+  "description": "All the data for a case",
   "type": "object",
   "required": [
-    "messageType",
-    "caseDetails"
+    "caseType",
+    "sourceCaseId",
+    "correspondentName",
+    "correspondenceEmail",
+    "caseStatus",
+    "caseStatusDate",
+    "creationDate",
+    "caseData",
+    "caseAttachments"
   ],
   "additionalProperties": false,
   "properties": {
-    "messageType": {
+    "caseType": {
       "type":"string"
     },
-    "caseDetails": {
+    "sourceCaseId": {
+      "type":"string"
+    },
+    "correspondentName": {
+      "type":"string"
+    },
+    "correspondenceEmail": {
+      "type":"string"
+    },
+    "caseStatus": {
+      "type":"string"
+    },
+    "caseStatusDate": {
+      "type":"string",
+      "format": "date"
+    },
+    "creationDate": {
+      "type": "string",
+      "format": "date"
+    },
+    "caseData": {
       "anyOf" : [
         {
-        "$ref": "#/definitions/caseDetails"
+          "$ref": "#/definitions/caseData"
+        }
+      ]
+    },
+    "caseAttachments": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/caseAttachments"
         }
       ]
     }

--- a/src/main/resources/hocs-migration-schema.json
+++ b/src/main/resources/hocs-migration-schema.json
@@ -5,12 +5,12 @@
   "definitions": {
     "caseDataItem": {
       "description": "Key value pair for one item of case data.",
-      "type": "array",
-      "minItems": 2,
-      "maxItems": 2,
-      "items": {
-        "type": "string"
-      }
+      "type": "object",
+      "properties": {
+        "name": {"type": "string"},
+        "value": {"type": "string"}
+      },
+      "additionalProperties": false
     },
     "caseData": {
       "description": "Array of case Data items",

--- a/src/main/resources/hocs-migration-schema.json
+++ b/src/main/resources/hocs-migration-schema.json
@@ -51,7 +51,7 @@
         ]
       }
     },
-    "case": {
+    "caseDetails": {
       "description": "All the data for a case",
       "type": "object",
       "required": [
@@ -110,17 +110,17 @@
   "type": "object",
   "required": [
     "messageType",
-    "case"
+    "caseDetails"
   ],
   "additionalProperties": false,
   "properties": {
     "messageType": {
       "type":"string"
     },
-    "case": {
+    "caseDetails": {
       "anyOf" : [
         {
-        "$ref": "#/definitions/case"
+        "$ref": "#/definitions/caseDetails"
         }
       ]
     }

--- a/src/test/java/uk/gov/digital/ho/hocs/migration/JSONValidate.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/migration/JSONValidate.java
@@ -40,10 +40,10 @@ public class JSONValidate {
             Set<ValidationMessage> validationMessages = testSchemaInvalid(schemaStream, jsonStream);
 
             Set<String> expectedMessages = new HashSet<>();
-            expectedMessages.add("$.caseDetails.additionalField: is not defined in the schema and the schema does not allow additional properties");
-            expectedMessages.add("$.caseDetails.caseData[0].value: integer found, string expected");
-            expectedMessages.add("$.caseDetails.caseData[1].third: is not defined in the schema and the schema does not allow additional properties");
-            expectedMessages.add("$.caseDetails.caseData[2].forth: is not defined in the schema and the schema does not allow additional properties");
+            expectedMessages.add("$.caseData[0].value: integer found, string expected");
+            expectedMessages.add("$.caseData[1].third: is not defined in the schema and the schema does not allow additional properties");
+            expectedMessages.add("$.caseData[2].forth: is not defined in the schema and the schema does not allow additional properties");
+            expectedMessages.add("$.additionalField: is not defined in the schema and the schema does not allow additional properties");
 
             assertTrue(checkForValidationMessage(validationMessages,expectedMessages));
         }

--- a/src/test/java/uk/gov/digital/ho/hocs/migration/JSONValidate.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/migration/JSONValidate.java
@@ -43,6 +43,7 @@ public class JSONValidate {
             expectedMessages.add("$.caseDetails.additionalField: is not defined in the schema and the schema does not allow additional properties");
             expectedMessages.add("$.caseDetails.caseData[0].value: integer found, string expected");
             expectedMessages.add("$.caseDetails.caseData[1].third: is not defined in the schema and the schema does not allow additional properties");
+            expectedMessages.add("$.caseDetails.caseData[2].forth: is not defined in the schema and the schema does not allow additional properties");
 
             assertTrue(checkForValidationMessage(validationMessages,expectedMessages));
         }

--- a/src/test/java/uk/gov/digital/ho/hocs/migration/JSONValidate.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/migration/JSONValidate.java
@@ -40,7 +40,9 @@ public class JSONValidate {
             Set<ValidationMessage> validationMessages = testSchemaInvalid(schemaStream, jsonStream);
 
             Set<String> expectedMessages = new HashSet<>();
-            expectedMessages.add("$.caseDetails.caseData[1]: there must be a maximum of 2 items in the array");
+            expectedMessages.add("$.caseDetails.additionalField: is not defined in the schema and the schema does not allow additional properties");
+            expectedMessages.add("$.caseDetails.caseData[0].value: integer found, string expected");
+            expectedMessages.add("$.caseDetails.caseData[1].third: is not defined in the schema and the schema does not allow additional properties");
 
             assertTrue(checkForValidationMessage(validationMessages,expectedMessages));
         }

--- a/src/test/java/uk/gov/digital/ho/hocs/migration/JSONValidate.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/migration/JSONValidate.java
@@ -65,6 +65,9 @@ public class JSONValidate {
     }
 
     private boolean checkForValidationMessage (Set<ValidationMessage> validationMessages, Set<String> expectedMessages){
+        if (validationMessages.size() != expectedMessages.size()) {
+            return false;
+        }
         for (String expectedMessage : expectedMessages){
             if (validationMessages.stream().noneMatch(o -> o.getMessage().equals(expectedMessage))){
                 return false;

--- a/src/test/java/uk/gov/digital/ho/hocs/migration/JSONValidate.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/migration/JSONValidate.java
@@ -40,7 +40,7 @@ public class JSONValidate {
             Set<ValidationMessage> validationMessages = testSchemaInvalid(schemaStream, jsonStream);
 
             Set<String> expectedMessages = new HashSet<>();
-            expectedMessages.add("$.case.caseData[1]: there must be a maximum of 2 items in the array");
+            expectedMessages.add("$.caseDetails.caseData[1]: there must be a maximum of 2 items in the array");
 
             assertTrue(checkForValidationMessage(validationMessages,expectedMessages));
         }

--- a/src/test/resources/jsonMigrationExamples/cms.json
+++ b/src/test/resources/jsonMigrationExamples/cms.json
@@ -9,8 +9,8 @@
     "caseStatusDate": "1947-02-14",
     "creationDate": "1965-06-22",
     "caseData": [
-      ["type", "cms"],
-      ["creationDate", "01/07/2022"]
+      {"name": "type", "value": "cms"},
+      {"name": "creationDate", "value": "01/07/2022"}
     ],
     "caseAttachments": [
       {

--- a/src/test/resources/jsonMigrationExamples/cms.json
+++ b/src/test/resources/jsonMigrationExamples/cms.json
@@ -1,6 +1,4 @@
 {
-  "messageType": "pariatur labore aliqua minim elit",
-  "caseDetails": {
     "caseType": "aliqua",
     "sourceCaseId": "in",
     "correspondentName": "Ut incididunt",
@@ -19,5 +17,4 @@
         "documentType": "deserunt laboris anim nisi"
       }
     ]
-  }
 }

--- a/src/test/resources/jsonMigrationExamples/cms.json
+++ b/src/test/resources/jsonMigrationExamples/cms.json
@@ -1,6 +1,6 @@
 {
   "messageType": "pariatur labore aliqua minim elit",
-  "case": {
+  "caseDetails": {
     "caseType": "aliqua",
     "sourceCaseId": "in",
     "correspondentName": "Ut incididunt",

--- a/src/test/resources/jsonMigrationExamples/invalid-case-data.json
+++ b/src/test/resources/jsonMigrationExamples/invalid-case-data.json
@@ -11,7 +11,8 @@
     "additionalField": "this is invalid",
     "caseData": [
       {"name": "type", "value": 1600},
-      {"name": "creationDate", "value": "01/07/2022", "third": "not allowed"}
+      {"name": "creationDate", "value": "01/07/2022", "third": "not allowed"},
+      {"forth":  "not allowed"}
     ],
     "caseAttachments": [
       {

--- a/src/test/resources/jsonMigrationExamples/invalid-case-data.json
+++ b/src/test/resources/jsonMigrationExamples/invalid-case-data.json
@@ -8,9 +8,10 @@
     "caseStatus": "tempor veniam ut laboris nulla",
     "caseStatusDate": "1947-02-14",
     "creationDate": "1965-06-22",
+    "additionalField": "this is invalid",
     "caseData": [
-      ["type", "cms"],
-      ["creationDate", "01/07/2022", "third data item"]
+      {"name": "type", "value": 1600},
+      {"name": "creationDate", "value": "01/07/2022", "third": "not allowed"}
     ],
     "caseAttachments": [
       {

--- a/src/test/resources/jsonMigrationExamples/invalid-case-data.json
+++ b/src/test/resources/jsonMigrationExamples/invalid-case-data.json
@@ -1,6 +1,6 @@
 {
   "messageType": "pariatur labore aliqua minim elit",
-  "case": {
+  "caseDetails": {
     "caseType": "aliqua",
     "sourceCaseId": "in",
     "correspondentName": "Ut incididunt",

--- a/src/test/resources/jsonMigrationExamples/invalid-case-data.json
+++ b/src/test/resources/jsonMigrationExamples/invalid-case-data.json
@@ -1,6 +1,4 @@
 {
-  "messageType": "pariatur labore aliqua minim elit",
-  "caseDetails": {
     "caseType": "aliqua",
     "sourceCaseId": "in",
     "correspondentName": "Ut incididunt",
@@ -21,5 +19,4 @@
         "documentType": "deserunt laboris anim nisi"
       }
     ]
-  }
 }


### PR DESCRIPTION
A small change to the schema because case is a reserved word in Java it makes it difficult to generate the JSON in code.

Use an object for the Case Data Item which is easier to generate in Java.