### PR TITLE
HOCS-5714: Add additionalCorrespondents to migration schema

### DIFF
--- a/src/main/resources/hocs-migration-schema.json
+++ b/src/main/resources/hocs-migration-schema.json
@@ -93,6 +93,19 @@
         "fullName",
         "correspondentType"
       ]
+    },
+    "additionalCorrespondents": {
+      "description": "Additional correspondents",
+      "type": "array",
+      "default": [],
+      "items": {
+        "type": "object",
+        "oneOf": [
+          {
+            "$ref": "#/definitions/correspondent"
+          }
+        ]
+      }
     }
   },
   "description": "All the data for a case",
@@ -119,6 +132,13 @@
       "oneOf": [
         {
           "$ref": "#/definitions/correspondent"
+        }
+      ]
+    },
+    "additionalCorrespondents": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/additionalCorrespondents"
         }
       ]
     },

--- a/src/test/java/uk/gov/digital/ho/hocs/migration/JSONValidate.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/migration/JSONValidate.java
@@ -112,6 +112,16 @@ public class JSONValidate {
         }
     }
 
+    @Test
+    public void testValidWithNoAdditionalCorrespondents() throws Exception {
+        try (
+                InputStream schemaStream = inputStreamFromClasspath("hocs-migration-schema.json");
+                InputStream jsonStream = inputStreamFromClasspath("jsonMigrationExamples/valid-migration-message-no-additional-correspondents.json")
+        ) {
+            testSchemaValid(schemaStream, jsonStream);
+        }
+    }
+
     private void testSchemaValid(InputStream schemaStream, InputStream jsonStream) throws IOException {
         byte[] jsonBytes = jsonStream.readAllBytes();
         JsonNode json = objectMapper.readTree(jsonBytes);

--- a/src/test/java/uk/gov/digital/ho/hocs/migration/JSONValidate.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/migration/JSONValidate.java
@@ -77,6 +77,41 @@ public class JSONValidate {
         }
     }
 
+    @Test
+    public void testValidAdditionalCorrespondent() throws Exception {
+        try (
+                InputStream schemaStream = inputStreamFromClasspath("hocs-migration-schema.json");
+                InputStream jsonStream = inputStreamFromClasspath("jsonMigrationExamples/valid-migration-message-additional-correspondent.json")
+        ) {
+            testSchemaValid(schemaStream, jsonStream);
+        }
+    }
+
+    @Test
+    public void testValidMultipleAdditionalCorrespondent() throws Exception {
+        try (
+                InputStream schemaStream = inputStreamFromClasspath("hocs-migration-schema.json");
+                InputStream jsonStream = inputStreamFromClasspath("jsonMigrationExamples/valid-migration-message-multiple-additional-correspondent.json")
+        ) {
+            testSchemaValid(schemaStream, jsonStream);
+        }
+    }
+
+    @Test
+    public void testInvalidAdditionalCorrespondentWithMissingMandatoryFields() throws Exception {
+        try (
+                InputStream schemaStream = inputStreamFromClasspath("hocs-migration-schema.json");
+                InputStream jsonStream = inputStreamFromClasspath("jsonMigrationExamples/invalid-migration-message-additional-correspondent-missing-mandatory-fields.json")
+        ) {
+            Set<ValidationMessage> validationMessages = testSchemaInvalid(schemaStream, jsonStream);
+            Set<String> expectedMessages = new HashSet<>();
+            expectedMessages.add("$.additionalCorrespondents[0].fullName: is missing but it is required");
+            expectedMessages.add("$.additionalCorrespondents[0].correspondentType: is missing but it is required");
+
+            assertTrue(checkForValidationMessage(validationMessages,expectedMessages));
+        }
+    }
+
     private void testSchemaValid(InputStream schemaStream, InputStream jsonStream) throws IOException {
         byte[] jsonBytes = jsonStream.readAllBytes();
         JsonNode json = objectMapper.readTree(jsonBytes);

--- a/src/test/resources/jsonMigrationExamples/invalid-migration-message-additional-correspondent-missing-mandatory-fields.json
+++ b/src/test/resources/jsonMigrationExamples/invalid-migration-message-additional-correspondent-missing-mandatory-fields.json
@@ -1,0 +1,44 @@
+{
+    "caseType": "caseType",
+    "sourceCaseId": "sourceCaseId",
+    "primaryCorrespondent": {
+      "fullName": "fullName",
+      "correspondentType": "COMPLAINANT",
+      "address1": "address1",
+      "address2": "address2",
+      "address3": "address3",
+      "postcode": "postcode",
+      "country": "country",
+      "organisation": "organisation",
+      "telephone": "telephone",
+      "email": "email",
+      "reference": "reference"
+    },
+    "additionalCorrespondents": [
+      {
+        "address1": "address1",
+        "address2": "address2",
+        "address3": "address3",
+        "postcode": "postcode",
+        "country": "country",
+        "organisation": "organisation",
+        "telephone": "telephone",
+        "email": "email",
+        "reference": "reference"
+      }
+    ],
+    "caseStatus": "caseStatus",
+    "caseStatusDate": "1947-02-14",
+    "creationDate": "1965-06-22",
+    "caseData": [
+      {"name": "type", "value": "cms"},
+      {"name": "creationDate", "value": "01/07/2022"}
+    ],
+    "caseAttachments": [
+      {
+        "path": "path",
+        "label": "label",
+        "documentType": "documentType"
+      }
+    ]
+}

--- a/src/test/resources/jsonMigrationExamples/valid-migration-message-additional-correspondent.json
+++ b/src/test/resources/jsonMigrationExamples/valid-migration-message-additional-correspondent.json
@@ -1,0 +1,46 @@
+{
+    "caseType": "caseType",
+    "sourceCaseId": "sourceCaseId",
+    "primaryCorrespondent": {
+      "fullName": "fullName",
+      "correspondentType": "COMPLAINANT",
+      "address1": "address1",
+      "address2": "address2",
+      "address3": "address3",
+      "postcode": "postcode",
+      "country": "country",
+      "organisation": "organisation",
+      "telephone": "telephone",
+      "email": "email",
+      "reference": "reference"
+    },
+    "additionalCorrespondents": [
+      {
+        "fullName": "fullName",
+        "correspondentType": "COMPLAINANT",
+        "address1": "address1",
+        "address2": "address2",
+        "address3": "address3",
+        "postcode": "postcode",
+        "country": "country",
+        "organisation": "organisation",
+        "telephone": "telephone",
+        "email": "email",
+        "reference": "reference"
+      }
+    ],
+    "caseStatus": "caseStatus",
+    "caseStatusDate": "1947-02-14",
+    "creationDate": "1965-06-22",
+    "caseData": [
+      {"name": "type", "value": "cms"},
+      {"name": "creationDate", "value": "01/07/2022"}
+    ],
+    "caseAttachments": [
+      {
+        "path": "path",
+        "label": "label",
+        "documentType": "documentType"
+      }
+    ]
+}

--- a/src/test/resources/jsonMigrationExamples/valid-migration-message-multiple-additional-correspondent.json
+++ b/src/test/resources/jsonMigrationExamples/valid-migration-message-multiple-additional-correspondent.json
@@ -1,0 +1,59 @@
+{
+    "caseType": "caseType",
+    "sourceCaseId": "sourceCaseId",
+    "primaryCorrespondent": {
+      "fullName": "fullName",
+      "correspondentType": "COMPLAINANT",
+      "address1": "address1",
+      "address2": "address2",
+      "address3": "address3",
+      "postcode": "postcode",
+      "country": "country",
+      "organisation": "organisation",
+      "telephone": "telephone",
+      "email": "email",
+      "reference": "reference"
+    },
+    "additionalCorrespondents": [
+      {
+        "fullName": "fullName",
+        "correspondentType": "COMPLAINANT",
+        "address1": "address1",
+        "address2": "address2",
+        "address3": "address3",
+        "postcode": "postcode",
+        "country": "country",
+        "organisation": "organisation",
+        "telephone": "telephone",
+        "email": "email",
+        "reference": "reference"
+      },
+      {
+        "fullName": "fullName",
+        "correspondentType": "COMPLAINANT",
+        "address1": "address1",
+        "address2": "address2",
+        "address3": "address3",
+        "postcode": "postcode",
+        "country": "country",
+        "organisation": "organisation",
+        "telephone": "telephone",
+        "email": "email",
+        "reference": "reference"
+      }
+    ],
+    "caseStatus": "caseStatus",
+    "caseStatusDate": "1947-02-14",
+    "creationDate": "1965-06-22",
+    "caseData": [
+      {"name": "type", "value": "cms"},
+      {"name": "creationDate", "value": "01/07/2022"}
+    ],
+    "caseAttachments": [
+      {
+        "path": "path",
+        "label": "label",
+        "documentType": "documentType"
+      }
+    ]
+}

--- a/src/test/resources/jsonMigrationExamples/valid-migration-message-no-additional-correspondents.json
+++ b/src/test/resources/jsonMigrationExamples/valid-migration-message-no-additional-correspondents.json
@@ -1,0 +1,31 @@
+{
+    "caseType": "caseType",
+    "sourceCaseId": "sourceCaseId",
+    "primaryCorrespondent": {
+      "fullName": "fullName",
+      "correspondentType": "COMPLAINANT",
+      "address1": "address1",
+      "address2": "address2",
+      "address3": "address3",
+      "postcode": "postcode",
+      "country": "country",
+      "organisation": "organisation",
+      "telephone": "telephone",
+      "email": "email",
+      "reference": "reference"
+    },
+    "caseStatus": "caseStatus",
+    "caseStatusDate": "1947-02-14",
+    "creationDate": "1965-06-22",
+    "caseData": [
+      {"name": "type", "value": "cms"},
+      {"name": "creationDate", "value": "01/07/2022"}
+    ],
+    "caseAttachments": [
+      {
+        "path": "path",
+        "label": "label",
+        "documentType": "documentType"
+      }
+    ]
+}


### PR DESCRIPTION
Add ability to include optional addition correspondents in a migration message. 
Additional correspondent must contain mandatory Correspondent fields. 