### PR TITLE
HOCS-5584: Add migration case attachments

### DIFF
--- a/src/main/resources/hocs-migration-schema.json
+++ b/src/main/resources/hocs-migration-schema.json
@@ -36,12 +36,13 @@
         },
         "documentType": {
           "description": "The document type",
-          "type": ["string", "null"]
+          "type": "string"
         }
       },
       "required": [
         "documentPath",
-        "displayName"
+        "displayName",
+        "documentType"
       ]
     },
     "caseAttachments": {

--- a/src/test/java/uk/gov/digital/ho/hocs/migration/JSONValidate.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/migration/JSONValidate.java
@@ -132,6 +132,25 @@ public class JSONValidate {
         }
     }
 
+    @Test
+    public void testInvalidWithNullFieldsForMandatoryValues() throws Exception {
+        try (
+                InputStream schemaStream = inputStreamFromClasspath("hocs-migration-schema.json");
+                InputStream jsonStream = inputStreamFromClasspath("jsonMigrationExamples/invalid-migration-message-null-mandatory-fields.json")
+        ) {
+            Set<ValidationMessage> validationMessages = testSchemaInvalid(schemaStream, jsonStream);
+
+            Set<String> expectedMessages = new HashSet<>();
+            expectedMessages.add("$.primaryCorrespondent.fullName: null found, string expected");
+            expectedMessages.add("$.primaryCorrespondent.correspondentType: null found, string expected");
+            expectedMessages.add("$.caseAttachments[0].displayName: null found, string expected");
+            expectedMessages.add("$.caseAttachments[0].documentPath: null found, string expected");
+            expectedMessages.add("$.caseAttachments[0].documentType: null found, string expected");
+
+            assertTrue(checkForValidationMessage(validationMessages,expectedMessages));
+        }
+    }
+
     private void testSchemaValid(InputStream schemaStream, InputStream jsonStream) throws IOException {
         byte[] jsonBytes = jsonStream.readAllBytes();
         JsonNode json = objectMapper.readTree(jsonBytes);
@@ -157,6 +176,7 @@ public class JSONValidate {
             Set<String> expectedMessages = new HashSet<>();
             expectedMessages.add("$.caseAttachments[0].documentPath: is missing but it is required");
             expectedMessages.add("$.caseAttachments[0].displayName: is missing but it is required");
+            expectedMessages.add("$.caseAttachments[0].documentType: is missing but it is required");
             assertTrue(checkForValidationMessage(validationMessages,expectedMessages));
         }
     }

--- a/src/test/resources/jsonMigrationExamples/invalid-migration-message-null-mandatory-fields.json
+++ b/src/test/resources/jsonMigrationExamples/invalid-migration-message-null-mandatory-fields.json
@@ -1,0 +1,31 @@
+{
+    "caseType": "caseType",
+    "sourceCaseId": "sourceCaseId",
+    "primaryCorrespondent": {
+      "fullName": null,
+      "correspondentType": null,
+      "address1": "",
+      "address2": "",
+      "address3": "",
+      "postcode": "",
+      "country": "",
+      "organisation": "",
+      "telephone": "",
+      "email": "",
+      "reference": ""
+    },
+    "caseStatus": "caseStatus",
+    "caseStatusDate": "1947-02-14",
+    "creationDate": "1965-06-22",
+    "caseData": [
+      {"name": "type", "value": "cms"},
+      {"name": "creationDate", "value": "01/07/2022"}
+    ],
+    "caseAttachments": [
+      {
+        "documentPath": null,
+        "displayName": null,
+        "documentType": null
+      }
+    ]
+}

--- a/src/test/resources/jsonMigrationExamples/valid-migration-message-with-nulls.json
+++ b/src/test/resources/jsonMigrationExamples/valid-migration-message-with-nulls.json
@@ -25,7 +25,7 @@
       {
         "documentPath": "path",
         "displayName": "label",
-        "documentType": null
+        "documentType": "type"
       }
     ]
 }


### PR DESCRIPTION
Change documentType as a required field, and non-nullable.
Test for valid and invalid scenarios. 